### PR TITLE
renamed 'users' to editors and add new subject matter expert field

### DIFF
--- a/code/extensions/ContentReviewDefaultSettings.php
+++ b/code/extensions/ContentReviewDefaultSettings.php
@@ -134,10 +134,10 @@ class ContentReviewDefaultSettings extends DataExtension
         $usersMap = $users->map('ID', 'Title')->toArray();
         asort($usersMap);
 
-        $userField = ListboxField::create('OwnerUsers', _t('ContentReview.PAGEOWNERUSERS', 'Users'), $usersMap)
+        $userField = ListboxField::create('OwnerUsers', _t('ContentReview.PAGEOWNERUSERS', 'Editors'), $usersMap)
             ->setMultiple(true)
             ->setAttribute('data-placeholder', _t('ContentReview.ADDUSERS', 'Add users'))
-            ->setDescription(_t('ContentReview.OWNERUSERSDESCRIPTION', 'Page owners that are responsible for reviews'));
+            ->setDescription(_t('ContentReview.OWNERUSERSDESCRIPTION', 'People who will get an email when page is ready for review'));
 
         $fields->addFieldToTab('Root.ContentReview', $userField);
 
@@ -153,7 +153,7 @@ class ContentReviewDefaultSettings extends DataExtension
         $groupField = ListboxField::create('OwnerGroups', _t('ContentReview.PAGEOWNERGROUPS', 'Groups'), $groupsMap)
             ->setMultiple(true)
             ->setAttribute('data-placeholder', _t('ContentReview.ADDGROUP', 'Add groups'))
-            ->setDescription(_t('ContentReview.OWNERGROUPSDESCRIPTION', 'Page owners that are responsible for reviews'));
+            ->setDescription(_t('ContentReview.OWNERGROUPSDESCRIPTION', 'Groups who will get an email when page is ready for review'));
 
         $fields->addFieldToTab('Root.ContentReview', $groupField);
 

--- a/code/extensions/SiteTreeContentReview.php
+++ b/code/extensions/SiteTreeContentReview.php
@@ -25,6 +25,7 @@ class SiteTreeContentReview extends DataExtension implements PermissionProvider
         "NextReviewDate"    => "Date",
         "LastEditedByName"  => "Varchar(255)",
         "OwnerNames"        => "Varchar(255)",
+        "SubjectMatterExpert" => "Varchar(255)",
         "ReviewInfo"        => "Text"
     );
 
@@ -313,7 +314,7 @@ class SiteTreeContentReview extends DataExtension implements PermissionProvider
         // Display read-only version only
         if (!Permission::check("EDIT_CONTENT_REVIEW_FIELDS")) {
             $schedule = self::get_schedule();
-            $contentOwners = ReadonlyField::create("ROContentOwners", _t("ContentReview.CONTENTOWNERS", "Content Owners"), $this->getOwnerNames());
+            $contentOwners = ReadonlyField::create("ROContentOwners", _t("ContentReview.CONTENTOWNERS", "Editors"), $this->getOwnerNames());
             $nextReviewAt = DateField::create('RONextReviewDate', _t("ContentReview.NEXTREVIEWDATE", "Next review date"), $this->owner->NextReviewDate);
 
             if (!isset($schedule[$this->owner->ReviewPeriodDays])) {
@@ -360,11 +361,11 @@ class SiteTreeContentReview extends DataExtension implements PermissionProvider
 
         asort($usersMap);
 
-        $userField = ListboxField::create("OwnerUsers", _t("ContentReview.PAGEOWNERUSERS", "Users"), $usersMap)
+        $userField = ListboxField::create("OwnerUsers", _t("ContentReview.PAGEOWNERUSERS", "Editors"), $usersMap)
             ->setMultiple(true)
             ->addExtraClass('custom-setting')
             ->setAttribute("data-placeholder", _t("ContentReview.ADDUSERS", "Add users"))
-            ->setDescription(_t('ContentReview.OWNERUSERSDESCRIPTION', 'Page owners that are responsible for reviews'));
+            ->setDescription(_t('ContentReview.OWNERUSERSDESCRIPTION', 'People who will get an email when page is ready for review'));
 
         $groupsMap = array();
 
@@ -377,7 +378,7 @@ class SiteTreeContentReview extends DataExtension implements PermissionProvider
             ->setMultiple(true)
             ->addExtraClass('custom-setting')
             ->setAttribute("data-placeholder", _t("ContentReview.ADDGROUP", "Add groups"))
-            ->setDescription(_t("ContentReview.OWNERGROUPSDESCRIPTION", "Page owners that are responsible for reviews"));
+            ->setDescription(_t("ContentReview.OWNERGROUPSDESCRIPTION", "Groups who will get an email when page is ready for review"));
 
         $reviewDate = DateField::create("NextReviewDate", _t("ContentReview.NEXTREVIEWDATE", "Next review date"))
             ->setConfig("showcalendar", true)
@@ -394,7 +395,7 @@ class SiteTreeContentReview extends DataExtension implements PermissionProvider
             ->setDescription(_t("ContentReview.REVIEWFREQUENCYDESCRIPTION", "The review date will be set to this far in the future whenever the page is published"));
 
         $reviewInfoField = TextareaField::create("ReviewInfo", _t("ContentReview.REVIEWINFO", "Review information"));
-
+        $subjectMatterExpert = TextField::create("SubjectMatterExpert", _t("ContentReview.SUBJECTMATTEREXPERT", 'Subject matter expert'));
         $notesField = GridField::create("ReviewNotes", "Review Notes", $this->owner->ReviewLogs(), GridFieldConfig_RecordEditor::create());
 
         $fields->addFieldsToTab("Root.ContentReview", array(
@@ -407,6 +408,7 @@ class SiteTreeContentReview extends DataExtension implements PermissionProvider
                 $reviewFrequency
             )->addExtraClass("review-settings"),
             ReadonlyField::create("ROContentOwners", _t("ContentReview.CONTENTOWNERS", "Content Owners"), $this->getOwnerNames()),
+            $subjectMatterExpert,
             $reviewInfoField,
             $notesField,
         ));

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -23,7 +23,7 @@ en:
     NOCOMMENTS: '(no comments)'
     OPTIONS: Options
     OWNERGROUPSDESCRIPTION: 'Groups who will get an email when page is ready for review'
-    OWNERUSERSDESCRIPTION: 'Page owners who will get an email when page is ready for reivew'
+    OWNERUSERSDESCRIPTION: 'People who will get an email when page is ready for review'
     PAGEOWNERGROUPS: Groups
     PAGEOWNERUSERS: Editors
     REVIEWFREQUENCY: 'Review frequency'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -4,7 +4,7 @@ en:
     ADDUSERS: 'Add users'
     BUTTONREVIEWED: 'Review content'
     COMMENTS: '(optional) Add comments...'
-    CONTENTOWNERS: 'Content Owners'
+    CONTENTOWNERS: 'Editors'
     CONTENTREVIEW: 'Content due for review'
     CUSTOM: 'Custom settings'
     DEFAULTSETTINGSHELP: 'These content review settings will apply to all pages that does not have specific Content Review schedule.'
@@ -22,10 +22,10 @@ en:
     NEXTREVIEWDATE: 'Next review date'
     NOCOMMENTS: '(no comments)'
     OPTIONS: Options
-    OWNERGROUPSDESCRIPTION: 'Page owners that are responsible for reviews'
-    OWNERUSERSDESCRIPTION: 'Page owners that are responsible for reviews'
+    OWNERGROUPSDESCRIPTION: 'Groups who will get an email when page is ready for review'
+    OWNERUSERSDESCRIPTION: 'Page owners who will get an email when page is ready for reivew'
     PAGEOWNERGROUPS: Groups
-    PAGEOWNERUSERS: Users
+    PAGEOWNERUSERS: Editors
     REVIEWFREQUENCY: 'Review frequency'
     REVIEWFREQUENCYDESCRIPTION: 'The review date will be set to this far in the future whenever the page is published'
     REVIEWHEADER: 'Content review'
@@ -36,6 +36,7 @@ en:
     SAVE: Save
     SECONDREVIEWDAYSBEFORE: 'Second review reminder # days before final review'
     SETTINGSFROM: 'Options are'
+    SUBJECTMATTEREXPERT: 'Subject matter expert'
   ContentReviewEmails:
     REVIEWPAGELINK: 'Review the page in the CMS'
     SUBJECT: 'Page(s) are due for content review'


### PR DESCRIPTION
This is part one of PORT-130 ticket 

This change to the forked content review module includes the following CMS usability changes:  

- renamed 'users' to 'editors' in content review tab
- updated helper text to be more helpful
- added a new db field for 'Subject Matter Expert' 

Part two is to create a report in the GOVTNZ repository to get the subject matter experts by page 

:tomato: 